### PR TITLE
Changed external anilist token to be sent through IPC from main to renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Miru",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "author": "ThaUnknown_ <ThaUnknown@users.noreply.github.com>",
   "main": "src/index.js",
   "homepage": "https://github.com/ThaUnknown/miru#readme",

--- a/src/index.js
+++ b/src/index.js
@@ -24,14 +24,14 @@ if (!gotTheLock) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
     }
-    if (commandLine.length === 3) {
-      let token = commandLine[2].slice(9)
-      if (token.endsWith('/')) token = token.slice(0, -1)
-      if (token) {
-        if (process.env.NODE_ENV !== 'development ') {
-          mainWindow.loadURL(path.join(__dirname, '/renderer/dist/index.html#' + token))
-        } else {
-          mainWindow.loadURL('http://localhost:3000#' + token)
+    // There's probably a better way to do this instead of a for loop and split[1][0]
+    // but for now it works as a way to fix multiple OS's commandLine differences
+    for (let i = 0; i < commandLine.length; i++) {
+      if (commandLine[i].startsWith('miru://')) {
+        let token = commandLine[i].split('access_token=')[1].split('&token_type')[0]
+        if (token.endsWith('/')) token = token.slice(0, -1)
+        if (token) {
+          mainWindow.webContents.send('altoken', token)
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,11 @@ if (!gotTheLock) {
     }
     // There's probably a better way to do this instead of a for loop and split[1][0]
     // but for now it works as a way to fix multiple OS's commandLine differences
-    for (let i = 0; i < commandLine.length; i++) {
-      if (commandLine[i].startsWith('miru://')) {
-        let token = commandLine[i].split('access_token=')[1].split('&token_type')[0]
-        if (token.endsWith('/')) token = token.slice(0, -1)
+    for (const line of commandLine) {
+      if (line.startsWith('miru://')) {
+        let token = line.split('access_token=')[1].split('&token_type')[0]
         if (token) {
+          if (token.endsWith('/')) token = token.slice(0, -1)
           mainWindow.webContents.send('altoken', token)
         }
       }

--- a/src/renderer/src/lib/pages/Settings.svelte
+++ b/src/renderer/src/lib/pages/Settings.svelte
@@ -1,15 +1,5 @@
 <script context="module">
-  function checkToken() {
-    const searchParams = new URLSearchParams(location.href)
-    if (searchParams.get('access_token')) {
-      localStorage.setItem('ALtoken', searchParams.get('access_token'))
-      location.hash = ''
-      location.reload()
-    }
-  }
-  checkToken()
-  window.addEventListener('hashchange', checkToken)
-  export const alToken = localStorage.getItem('ALtoken') || null
+  export let alToken = localStorage.getItem('ALtoken') || null
   const defaults = {
     playerAutoplay: true,
     playerPause: true,
@@ -31,6 +21,7 @@
   })
   window.IPC.on('altoken', data => {
     localStorage.setItem('ALtoken', data)
+    alToken = data
     location.reload()
   })
 </script>

--- a/src/renderer/src/lib/pages/Settings.svelte
+++ b/src/renderer/src/lib/pages/Settings.svelte
@@ -29,6 +29,10 @@
   window.IPC.on('path', data => {
     set.torrentPath = data
   })
+  window.IPC.on('altoken', data => {
+    localStorage.setItem('ALtoken', data)
+    location.reload()
+  })
 </script>
 
 <script>


### PR DESCRIPTION
This mainly fixes linux anilist login issues due to commandLine size and args being different across platforms.
As commented, there's probably a better way to do this instead of a for loop and split[1][0] but for now it simply works.
Haven't tested on windows but it should be good from what I can see.
You might want to make changes to `checkToken` on `Settings.svelte` to completely remove search params for anilist token, I haven't touched it myself because there are multiple instances and I don't know the entire app structure and what could break if removed.