### PR TITLE
build: enable 32bit targets for Windows and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,12 @@
     },
     "win": {
       "artifactName": "${name}-${os}-${arch}-${version}.${ext}",
-      "target": "nsis"
+      "target": [
+        {
+          "target": "nsis",
+          "arch": ["x64", "ia32"]
+        }
+      ]
     },
     "linux": {
       "artifactName": "${name}-${os}-${arch}-${version}.${ext}",
@@ -77,7 +82,7 @@
           "target": "AppImage"
         },
         {
-          "arch": "x64",
+          "arch": ["x64", "ia32", "arm64", "armv7l"],
           "target": "deb"
         }
       ],
@@ -87,6 +92,7 @@
     },
     "nsis": {
       "allowToChangeInstallationDirectory": true,
+      "perMachine": false,
       "oneClick": false
     }
   },


### PR DESCRIPTION
### Description
- Enables `ia32` target for Windows/Linux
- Enables `arm64`/`armv7l` target for Linux

Not really much but I think people somehow still on 32-bit devices should still be able to stream anime :P