### PR TITLE
Add sharing and opening in external browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,13 +22,15 @@ if (!app.requestSingleInstanceLock()) {
     // There's probably a better way to do this instead of a for loop and split[1][0]
     // but for now it works as a way to fix multiple OS's commandLine differences
     for (const line of commandLine) {
-      if (line.startsWith('miru://')) return sendToken(line)
+      if (line.startsWith('miru://auth')) return sendToken(line)
+      if (line.startsWith('miru://anime/')) return openAnime(line)
     }
   })
 }
 app.on('open-url', (event, url) => {
   event.preventDefault()
-  if (url.startsWith('miru://')) sendToken(url)
+  if (url.startsWith('miru://auth')) sendToken(url)
+  if (url.startsWith('miru://anime/')) openAnime(url)
 })
 
 function sendToken (line) {
@@ -36,6 +38,13 @@ function sendToken (line) {
   if (token) {
     if (token.endsWith('/')) token = token.slice(0, -1)
     mainWindow.webContents.send('altoken', token)
+  }
+}
+
+function openAnime (url) {
+  const animeId = url.split('anime/')[1]
+  if (animeId) {
+    mainWindow.webContents.send('open-anime', animeId)
   }
 }
 

--- a/src/renderer/src/App.svelte
+++ b/src/renderer/src/App.svelte
@@ -1,9 +1,14 @@
 <script context="module">
   import { setContext } from 'svelte'
   import { writable } from 'svelte/store'
+  import { alRequest } from '@/modules/anilist.js'
 
   export const page = writable('home')
   export const view = writable(null)
+  export async function handleAnime(anime) {
+    view.set(null)
+    view.set((await alRequest({ method: 'SearchIDSingle', id: anime })).data.Media)
+  }
 </script>
 
 <script>
@@ -23,6 +28,7 @@
   setContext('gallery', writable(null))
 
   setContext('trailer', writable(null))
+  window.IPC.on('open-anime', handleAnime)
 </script>
 
 <Toasts />

--- a/src/renderer/src/lib/Sidebar.svelte
+++ b/src/renderer/src/lib/Sidebar.svelte
@@ -61,7 +61,7 @@
           location.hash = ''
           location.reload()
         } else {
-          window.IPC.emit('open', 'https://anilist.co/api/v2/oauth/authorize?client_id=4254&response_type=token')
+          window.IPC.emit('open', 'https://anilist.co/api/v2/oauth/authorize?client_id=4254&response_type=token') //Change redirect_url to miru://auth
           if (platformMap[window.version.platform] === 'Linux') {
             addToast({
               text: "If your linux distribution doesn't support custom protocol handlers, you can simply paste the full URL into the app.",

--- a/src/renderer/src/lib/ViewAnime.svelte
+++ b/src/renderer/src/lib/ViewAnime.svelte
@@ -5,6 +5,7 @@
   import { getContext } from 'svelte'
   import { alToken } from '@/lib/pages/Settings.svelte'
   import { countdown } from '@/modules/util.js'
+  import { addToast } from './Toasts.svelte'
 
   const view = getContext('view')
   function close () {
@@ -79,6 +80,18 @@
   const trailer = getContext('trailer')
   function viewTrailer (media) {
     $trailer = media.trailer.id
+  }
+  function copyToClipboard(text) {
+    navigator.clipboard.writeText(text)
+    addToast({
+      title: 'Copied to clipboard',
+      text: 'Copied share URL to clipboard',
+      type: 'primary',
+      duration: '5000'
+    })
+  }
+  function openInBrowser(url) {
+    window.IPC.emit('open', url)
   }
 </script>
 
@@ -180,6 +193,16 @@
                         Trailer
                       </button>
                     {/if}
+                    <div class="d-flex mb-5 w-full">
+                      <button class="btn flex-fill font-weight-bold font-size-16 shadow-lg d-flex align-items-center" on:click={() => {openInBrowser(`https://anilist.co/anime/${media.id}`)}}>
+                        <span class="material-icons mr-5 font-size-18 w-30"> open_in_new </span>
+                        Open
+                      </button>
+                      <button class="btn flex-fill font-weight-bold font-size-16 shadow-lg d-flex align-items-center" on:click={() => {copyToClipboard(`<miru://anime/${media.id}>`)}}>
+                        <span class="material-icons mr-5 font-size-18 w-30"> share </span>
+                        Share
+                      </button>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
Added #190 
![image](https://user-images.githubusercontent.com/45773844/177225998-025f8c95-a08f-4f77-acac-509e0255503c.png)

Currently discord doesn't allow custom schemes to be clickable so a bypass is needed, probably something like a website that with a GET parameter redirects to miru://anime/[alid]

We could also add this mechanic to make joining watch together lobbies easier.