### PR TITLE
Winget Github Action

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,14 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: WinGet Releaser
+        uses: vedantmgoyal2009/winget-releaser@v1
+        with:
+          identifier: ThaUnknown.Miru
+          installers-regex: '\.exe$'
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Continuation of [this PR](https://github.com/ThaUnknown/miru/pull/215).

As per request:
- Tested it
- Squashed the commits in one. But I made some mistakes in git and it closed the other PR (my bad).
- The secret is used is for accessing your repo by creating a public token, [here](https://github.com/marketplace/actions/winget-releaser#getting-started-) are instructions on how to do this, else the pipeline doesn't have access according to the Action. If you want I can change mine to an infinite time token as well.

And a small explanation of how Winget works:
I [created a basic script](https://github.com/nlxdodge/miru-winget-upgrade/blob/main/miru_new_version.ps1) to update it manually before I found out that there are other better options available.

When setting up any application for Winget for the first time it always has to be done manually by using:
`wingetcreate new URL` this will make the default respository structure `manifests/A/company/maintainer/Application/` where by the A is the first letter of the maintainer.

As example your package is under `manifests/t/ThaUnknown/Miru/` where it has subfolders for each release version.
There per release it houses at least one `yaml` file for the basic items. An `installers.yaml` for all the `.exe`, `.msi` etc. or how many installers for ARM, x86 or x64 you have and finally some language file where `en-US` is the default one that is being made.

I added some things myself as well like tags and the description, that will be copied and pasted when running the update command from wingetcreate. For example, I used `wingetcreate update -u "$url|x64" -v "$version" -o "$working_directory" ThaUnknown.Miru` in my script to update the current in master latest manifest with the new release url and version number (and special output directory). for the given package.

If this is all done in Windows you can use `winget search miru` giving you the Maintainer.Application combo to install the program (if some programs have the same name but are maintained by someone else). So `winget install ThaUnknown.Miru` but just `miru` should also work as there is only one search result right now.

Another nice website I use is [winget.run](https://winget.run/pkg/ThaUnknown/Miru) where it reads the Github master branch to a nice website.

But I highly recommend to read more about it if you want to with the official [documentation](https://github.com/microsoft/winget-pkgs/blob/master/AUTHORING_MANIFESTS.md) though. Or read more from the [root of the Github Repo](https://github.com/microsoft/winget-pkgs).




