### PR TITLE
Use the native MacOS window controls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,8 @@ function createWindow () {
   mainWindow = new BrowserWindow({
     width: 1600,
     height: 900,
-    frame: false,
+    frame: process.platform === 'darwin', // Only keep the native frame on Mac
+    titleBarStyle: 'hidden',
     backgroundColor: '#191c20',
     autoHideMenuBar: true,
     webPreferences: {

--- a/src/renderer/src/lib/Menubar.svelte
+++ b/src/renderer/src/lib/Menubar.svelte
@@ -3,11 +3,11 @@
   export const title = writable('Miru')
 </script>
 
-<div class='w-full navbar border-0 bg-dark position-relative p-0'>
+<div class='w-full navbar draggable border-0 bg-dark position-relative p-0'>
   <div class='menu-shadow shadow-lg position-absolute w-full h-full z-0' />
   <div class='w-full h-full bg-dark z-10 d-flex'>
     {#if window.version.platform !== 'darwin'}
-      <div class='d-flex w-full draggable h-full align-items-center'>
+      <div class='d-flex w-full h-full align-items-center'>
         <img src='./logo.ico' alt='ico' />
         {$title}
       </div>

--- a/src/renderer/src/lib/Menubar.svelte
+++ b/src/renderer/src/lib/Menubar.svelte
@@ -6,27 +6,29 @@
 <div class='w-full navbar border-0 bg-dark position-relative p-0'>
   <div class='menu-shadow shadow-lg position-absolute w-full h-full z-0' />
   <div class='w-full h-full bg-dark z-10 d-flex'>
-    <div class='d-flex w-full draggable h-full align-items-center'>
-      <img src='./logo.ico' alt='ico' />
-      {$title}
-    </div>
-    <div class='controls d-flex h-full pointer'>
-      <div class='d-flex align-items-center' on:click={() => window.IPC.emit('minimize')}>
-        <svg viewBox='0 0 24 24'>
-          <path d='M19 13H5v-2h14v2z' />
-        </svg>
+    {#if window.version.platform !== 'darwin'}
+      <div class='d-flex w-full draggable h-full align-items-center'>
+        <img src='./logo.ico' alt='ico' />
+        {$title}
       </div>
-      <div class='d-flex align-items-center' on:click={() => window.IPC.emit('maximize')}>
-        <svg viewBox='0 0 24 24'>
-          <path d='M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z' />
-        </svg>
+      <div class='controls d-flex h-full pointer'>
+        <div class='d-flex align-items-center' on:click={() => window.IPC.emit('minimize')}>
+          <svg viewBox='0 0 24 24'>
+            <path d='M19 13H5v-2h14v2z' />
+          </svg>
+        </div>
+        <div class='d-flex align-items-center' on:click={() => window.IPC.emit('maximize')}>
+          <svg viewBox='0 0 24 24'>
+            <path d='M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z' />
+          </svg>
+        </div>
+        <div class='d-flex align-items-center close' on:click={() => window.IPC.emit('close')}>
+          <svg viewBox='0 0 24 24'>
+            <path d='M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z' />
+          </svg>
+        </div>
       </div>
-      <div class='d-flex align-items-center close' on:click={() => window.IPC.emit('close')}>
-        <svg viewBox='0 0 24 24'>
-          <path d='M19 6.41 17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12 19 6.41z' />
-        </svg>
-      </div>
-    </div>
+    {/if}
   </div>
 </div>
 

--- a/src/renderer/src/lib/Menubar.svelte
+++ b/src/renderer/src/lib/Menubar.svelte
@@ -3,14 +3,16 @@
   export const title = writable('Miru')
 </script>
 
-<div class='w-full navbar draggable border-0 bg-dark position-relative p-0'>
+<div class='w-full navbar border-0 bg-dark position-relative p-0'>
   <div class='menu-shadow shadow-lg position-absolute w-full h-full z-0' />
   <div class='w-full h-full bg-dark z-10 d-flex'>
-    {#if window.version.platform !== 'darwin'}
-      <div class='d-flex w-full h-full align-items-center'>
+    <div class='d-flex w-full h-full draggable align-items-center'>
+      {#if window.version.platform !== 'darwin'}
         <img src='./logo.ico' alt='ico' />
         {$title}
-      </div>
+      {/if}
+    </div>
+    {#if window.version.platform !== 'darwin'}
       <div class='controls d-flex h-full pointer'>
         <div class='d-flex align-items-center' on:click={() => window.IPC.emit('minimize')}>
           <svg viewBox='0 0 24 24'>


### PR DESCRIPTION
This PR tweaks the UI, so that it uses the native macOS traffic lights. It includes an invisible draggable area on top, and only gets applied if the user is running on the `darwin` platform. *Shouldn't* affect non-Mac builds.

Comparisons:
| Old | New |
-----|------
<img width="1712" alt="old" src="https://user-images.githubusercontent.com/25076630/233725731-e8898282-6ab2-4984-851f-429d52c4b17e.png"> | <img width="1712" alt="new-minimized-sidebar" src="https://user-images.githubusercontent.com/25076630/233725741-06abc40d-7c88-4c5d-a394-b3b9e1f23b5a.png">
<img width="1712" alt="old-expanded" src="https://user-images.githubusercontent.com/25076630/233726023-16b4201a-711b-43ef-a6a3-7b05b9c727f3.png"> | <img width="1712" alt="new-expanded-sidebar" src="https://user-images.githubusercontent.com/25076630/233725751-627de5e4-4f20-4c17-bed3-26a22bbb3f12.png">
