### PR TITLE
Add an option to control Discord RPC. (Fix issue #157)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,31 @@ let status = null
 const discord = new Client({
   transport: 'ipc'
 })
-function setDiscordRPC (event, data) {
+
+function setDiscordRPC (data) {
+  if (!data) {
+    data = {
+      activity: {
+        timestamps: {
+          start: Date.now()
+        },
+        details: 'Stream anime torrents, real-time.',
+        state: 'Watching anime',
+        assets: {
+          small_image: 'logo',
+          small_text: 'https://github.com/ThaUnknown/miru'
+        },
+        buttons: [
+          {
+            label: 'Download app',
+            url: 'https://github.com/ThaUnknown/miru/releases/latest'
+          }
+        ],
+        instance: true,
+        type: 3
+      }
+    }
+  }
   status = data
   if (discord?.user && status) {
     status.pid = process.pid
@@ -258,9 +282,39 @@ function setDiscordRPC (event, data) {
   }
 }
 
-ipcMain.on('discord', setDiscordRPC)
+let allowDiscordDetails = false
+let requestedDiscordDetails = false
+let rpcStarted = false
+let cachedPresence = null
+
+ipcMain.on('discord_status', (event, data) => {
+  requestedDiscordDetails = data;
+  if (!rpcStarted) {
+    handleRPC()
+    setInterval(handleRPC, 5000) //According to Discord documentation, clients can only update their presence 5 times per 20 seconds. We will add an extra second to be safe.
+    rpcStarted = true
+  }
+})
+
+function handleRPC() {
+  if (allowDiscordDetails === requestedDiscordDetails) return
+
+  allowDiscordDetails = requestedDiscordDetails
+  if (!allowDiscordDetails) {
+    setDiscordRPC(null)
+  } else if (cachedPresence) {
+    setDiscordRPC(cachedPresence)
+  }
+}
+
+ipcMain.on('discord', (event, data) => {
+  cachedPresence = data
+  if (allowDiscordDetails) {
+    setDiscordRPC(data)
+  }
+})
 discord.on('ready', async () => {
-  setDiscordRPC(null, status)
+  setDiscordRPC(status)
   discord.subscribe('ACTIVITY_JOIN_REQUEST')
   discord.subscribe('ACTIVITY_JOIN')
   discord.subscribe('ACTIVITY_SPECTATE')

--- a/src/renderer/src/lib/Settings.svelte
+++ b/src/renderer/src/lib/Settings.svelte
@@ -19,7 +19,8 @@
     enableDoH: false,
     doHURL: 'https://cloudflare-dns.com/dns-query',
     disableSubtitleBlur: false,
-    catURL: decodeURIComponent(atob('aHR0cHMlM0ElMkYlMkZueWFhLnNp'))
+    catURL: decodeURIComponent(atob('aHR0cHMlM0ElMkYlMkZueWFhLnNp')),
+    showDetailsInRPC: true
   }
   localStorage.removeItem('relations') // TODO: remove
   export const set = { ...defaults, ...(JSON.parse(localStorage.getItem('settings')) || {}) }
@@ -90,6 +91,7 @@
     const json = await res.json()
     return json.map(({ body, tag_name: version }) => ({ body, version }))
   })()
+  window.IPC.emit('discord_status', set.showDetailsInRPC)
 </script>
 
 <script>
@@ -117,6 +119,11 @@
       icon: 'hub',
       desc: 'Torrent client settings, and preferences.'
     },
+    discord: {
+      name: 'Discord',
+      icon: 'discord',
+      desc: 'Discord Rich Presence settings.'
+    },
     changelog: {
       name: 'Changelog',
       icon: 'list',
@@ -125,6 +132,7 @@
   }
   let settings = set
   $: saveSettings(settings)
+  $: window.IPC.emit('discord_status', settings.showDetailsInRPC)
   function saveSettings () {
     localStorage.setItem('settings', JSON.stringify(settings))
   }
@@ -464,6 +472,18 @@
             data-title='Disables Peer Exchange For Use In Private Trackers To Improve Privacy'>
             <input type='checkbox' id='torrent-pex' bind:checked={settings.torrentPeX} />
             <label for='torrent-pex'>Disable PeX</label>
+          </div>
+        </div>
+      </Tab>
+      <Tab>
+        <div class='root p-20 m-20'>
+          <div
+            class='custom-switch mb-10 pl-10 font-size-16 w-300'
+            data-toggle='tooltip'
+            data-placement='bottom'
+            data-title='Enables showing currently played anime and episode in Discord Rich Presence.'>
+            <input type='checkbox' id="rpc-details" bind:checked={settings.showDetailsInRPC}/>
+            <label for='rpc-details'>Show details in Discord Rich Presence</label>
           </div>
         </div>
       </Tab>

--- a/src/renderer/src/lib/Settings.svelte
+++ b/src/renderer/src/lib/Settings.svelte
@@ -481,7 +481,7 @@
             class='custom-switch mb-10 pl-10 font-size-16 w-300'
             data-toggle='tooltip'
             data-placement='bottom'
-            data-title='Enables showing currently played anime and episode in Discord Rich Presence.'>
+            data-title='Shows currently played anime and episode in Discord Rich Presence.'>
             <input type='checkbox' id="rpc-details" bind:checked={settings.showDetailsInRPC}/>
             <label for='rpc-details'>Show details in Discord Rich Presence</label>
           </div>


### PR DESCRIPTION
This PR adds a new tab under settings that control Discord RPC. Currently, it only has one switch: toggle ON/OFF. In the future, we could add an option controlling what exactly displays in the RPC. 

I realize that issue #157 was closed, but if I understand correctly, it was closed because of inactivity.
I've tested it, and it works correctly.