### PR TITLE
Fix #287

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -254,7 +254,31 @@ let status = null
 const discord = new Client({
   transport: 'ipc'
 })
-function setDiscordRPC (event, data) {
+
+function setDiscordRPC (data) {
+  if (!data) {
+    data = {
+      activity: {
+        timestamps: {
+          start: Date.now()
+        },
+        details: 'Stream anime torrents, real-time.',
+        state: 'Watching anime',
+        assets: {
+          small_image: 'logo',
+          small_text: 'https://github.com/ThaUnknown/miru'
+        },
+        buttons: [
+          {
+            label: 'Download app',
+            url: 'https://github.com/ThaUnknown/miru/releases/latest'
+          }
+        ],
+        instance: true,
+        type: 3
+      }
+    }
+  }
   status = data
   if (discord?.user && status) {
     status.pid = process.pid
@@ -262,9 +286,39 @@ function setDiscordRPC (event, data) {
   }
 }
 
-ipcMain.on('discord', setDiscordRPC)
+let allowDiscordDetails = false
+let requestedDiscordDetails = false
+let rpcStarted = false
+let cachedPresence = null
+
+ipcMain.on('discord_status', (event, data) => {
+  requestedDiscordDetails = data;
+  if (!rpcStarted) {
+    handleRPC()
+    setInterval(handleRPC, 5000) //According to Discord documentation, clients can only update their presence 5 times per 20 seconds. We will add an extra second to be safe.
+    rpcStarted = true
+  }
+})
+
+function handleRPC() {
+  if (allowDiscordDetails === requestedDiscordDetails) return
+
+  allowDiscordDetails = requestedDiscordDetails
+  if (!allowDiscordDetails) {
+    setDiscordRPC(null)
+  } else if (cachedPresence) {
+    setDiscordRPC(cachedPresence)
+  }
+}
+
+ipcMain.on('discord', (event, data) => {
+  cachedPresence = data
+  if (allowDiscordDetails) {
+    setDiscordRPC(data)
+  }
+})
 discord.on('ready', async () => {
-  setDiscordRPC(null, status)
+  setDiscordRPC(status)
   discord.subscribe('ACTIVITY_JOIN_REQUEST')
   discord.subscribe('ACTIVITY_JOIN')
   discord.subscribe('ACTIVITY_SPECTATE')

--- a/src/renderer/views/Settings.svelte
+++ b/src/renderer/views/Settings.svelte
@@ -121,7 +121,7 @@
     },
     discord: {
       name: 'Discord',
-      icon: 'discord',
+      icon: 'settings',
       desc: 'Discord Rich Presence settings.'
     },
     changelog: {


### PR DESCRIPTION
I've readded the relevant main.js part that was accidentally deleted 764c5a151975651aa119d92a90edb690e89b34b2
I've changed the non-working icon into a temporary solution (the icon "settings") because using the Discord logo would require reworking the system.

_PS: Please ensure that you won't again accidentally delete this PR when merging the remote into your local branch._