### PR TITLE
Show native window frame on Linux.

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -130,7 +130,7 @@ function createWindow () {
   mainWindow = new BrowserWindow({
     width: 1600,
     height: 900,
-    frame: process.platform === 'darwin', // Only keep the native frame on Mac
+    frame: process.platform !== 'win32', // Frame overriding only really works on Windows.
     titleBarStyle: 'hidden',
     titleBarOverlay: {
       color: '#17191c',


### PR DESCRIPTION
Close #291 
Unfortunately, there's no more customization we can do because of Electron.
I've tested this on Windows and it seems to work the same as before, don't have a Mac to test this.