### PR TITLE
Use cache directory as provided by env-paths to store files

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "electron-builder": "^24.4.0",
     "electron-log": "^4.4.8",
     "electron-updater": "^6.1.1",
+    "env-paths": "^3.0.0",
     "eslint": "^8.45.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-svelte": "^2.32.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ devDependencies:
   electron-updater:
     specifier: ^6.1.1
     version: 6.1.1
+  env-paths:
+    specifier: ^3.0.0
+    version: 3.0.0
   eslint:
     specifier: ^8.45.0
     version: 8.45.0
@@ -2480,6 +2483,11 @@ packages:
   /env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+    dev: true
+
+  /env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dev: true
 
   /envinfo@7.10.0:

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -4,6 +4,8 @@ import { ipcRenderer } from 'electron'
 import { pipeline } from 'streamx'
 import HTTPTracker from 'bittorrent-tracker/lib/client/http-tracker.js'
 import { hex2bin, bin2hex, arr2text, hex2arr } from 'uint8-util'
+import envPaths from 'env-paths'
+import { mkdirSync } from 'node:fs'
 
 class TorrentClient extends WebTorrent {
   constructor (settings) {
@@ -219,9 +221,13 @@ class TorrentClient extends WebTorrent {
 let client = null
 let message = null
 
+const cacheDir = envPaths("miru").cache
+mkdirSync(cacheDir, { recursive: true })
+
 ipcRenderer.on('port', (e) => {
   e.ports[0].onmessage = ({ data }) => {
     const cloned = structuredClone(data)
+    if (cloned.type === 'settings' && !cloned.data.torrentPath) cloned.data.torrentPath = cacheDir
     if (!client && cloned.type === 'settings') window.client = client = new TorrentClient(cloned.data)
     if (cloned.type === 'destroy') client?.predestroy()
 


### PR DESCRIPTION
Webtorrent (and Miru) saves downloads to tmp dir by default, which can lead to potential issues like described in #284. On most Linux distros `/tmp` is mounted as a `tmpfs` ram-disk. With large files being downloaded or `persist files` option turned on, `tmpfs` mount can run out of allocated space crashing Webtorrent.
Also, temp dir contents get wiped on reboot in many configurations, making `persist files` not work without specifying save location.

This PR uses [`env-paths`](https://github.com/sindresorhus/env-paths#pathscache) to determine OS-specific `cache` directory and use it to save downloads. All these dirs are under user home dir, so there should be no permission problems or other unexpected behavior.
