### PR TITLE
fix: build failing on macos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,9 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
+      - name: Install Setuptools for Python
+        run: pip3 install setuptools
+
       - name: Check out Git repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
All builds passing - https://github.com/Waaiez/miru/actions/runs/6818779931
^ Had to remove the publish code for testing there because for the life of me I cant remember how to change the publish location to my fork and its late

But anyway, this pr just install setuptools for python before anything
As seen in discord distutils was remove in python 3.12

[Changelog](https://docs.python.org/dev/whatsnew/3.12.html)
> [PEP 632](https://peps.python.org/pep-0632/): Remove the distutils package. See [the migration guide](https://peps.python.org/pep-0632/#migration-advice) for advice replacing the APIs it provided. The third-party [Setuptools](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html) package continues to provide distutils, if you still require it in Python 3.12 and beyond.
