### PR TITLE
Customisable seek duration

### DIFF
--- a/common/modules/util.js
+++ b/common/modules/util.js
@@ -147,6 +147,7 @@ export const defaults = {
   playerAutoplay: true,
   playerPause: true,
   playerAutocomplete: true,
+  playerSeek: 2,
   rssQuality: '1080',
   rssFeedsNew: [['New Releases', 'SubsPlease']],
   rssAutoplay: true,

--- a/common/views/Player/Player.svelte
+++ b/common/views/Player/Player.svelte
@@ -288,10 +288,10 @@
     video.currentTime = targetTime
   }
   function forward () {
-    seek(2)
+    seek($settings.playerSeek)
   }
   function rewind () {
-    seek(-2)
+    seek(-$settings.playerSeek)
   }
   function selectAudio (id) {
     if (id !== undefined) {
@@ -397,7 +397,7 @@
   }
   let fitWidth = false
   let showKeybinds = false
-  loadWithDefaults({
+  const ld = () => loadWithDefaults({
     KeyX: {
       fn: () => screenshot(),
       id: 'screenshot_monitor',
@@ -409,7 +409,10 @@
       type: 'icon'
     },
     Backquote: {
-      fn: () => (showKeybinds = !showKeybinds),
+      fn: () => {
+        ld();
+        (showKeybinds = !showKeybinds);
+      },
       id: 'help_outline',
       type: 'icon'
     },
@@ -464,11 +467,11 @@
     },
     ArrowLeft: {
       fn: () => rewind(),
-      id: '-2'
+      id: `-${$settings.playerSeek}`
     },
     ArrowRight: {
       fn: () => forward(),
-      id: '+2'
+      id: `+${$settings.playerSeek}`
     },
     ArrowUp: {
       fn: () => (volume = Math.min(1, volume + 0.05)),
@@ -518,6 +521,7 @@
     container.append(canvas)
     return { stream: canvas.captureStream(), destroy }
   }
+  ld()
 
   // function initCast (event) {
   //   // these quality settings are likely to make cast overheat, oh noes!

--- a/common/views/Player/Player.svelte
+++ b/common/views/Player/Player.svelte
@@ -409,10 +409,7 @@
       type: 'icon'
     },
     Backquote: {
-      fn: () => {
-        ld();
-        (showKeybinds = !showKeybinds);
-      },
+      fn: () => toggleKeybinds(false),
       id: 'help_outline',
       type: 'icon'
     },
@@ -499,6 +496,12 @@
       type: 'icon'
     }
   })
+  ld()
+
+  function toggleKeybinds (always) {
+    ld()
+    showKeybinds = always || !showKeybinds
+  }
 
   function getBurnIn (noSubs) {
     const canvas = document.createElement('canvas')
@@ -521,7 +524,6 @@
     container.append(canvas)
     return { stream: canvas.captureStream(), destroy }
   }
-  ld()
 
   // function initCast (event) {
   //   // these quality settings are likely to make cast overheat, oh noes!
@@ -1015,7 +1017,7 @@
         <input class='ctrl h-full custom-range' type='range' min='0' max='1' step='any' data-name='setVolume' bind:value={volume} />
       </div>
       <div class='ts mr-auto'>{toTS(targetTime, safeduration > 3600 ? 2 : 3)} / {toTS(safeduration - targetTime, safeduration > 3600 ? 2 : 3)}</div>
-      <span class='material-symbols-outlined ctrl' title='Keybinds [`]' use:click={() => (showKeybinds = true)}> keyboard </span>
+      <span class='material-symbols-outlined ctrl' title='Keybinds [`]' use:click={() => toggleKeybinds(true)}> keyboard </span>
       {#if 'audioTracks' in HTMLVideoElement.prototype && video?.audioTracks?.length > 1}
         <div class='dropdown dropup with-arrow' use:click={toggleDropdown}>
           <span class='material-symbols-outlined ctrl' title='Audio Tracks'>

--- a/common/views/Settings/PlayerSettings.svelte
+++ b/common/views/Settings/PlayerSettings.svelte
@@ -125,3 +125,11 @@
     <label for='player-autocomplete'>{settings.playerAutocomplete ? 'On' : 'Off'}</label>
   </div>
 </SettingCard>
+<SettingCard title='Seek Duration' description='Seconds to seek an episode with arrow keys'>
+  <div class='input-group w-100 mw-full'>
+    <input type='number' bind:value={settings.playerSeek} min='1' max='50' class='form-control text-right bg-dark' />
+    <div class='input-group-append'>
+      <span class='input-group-text bg-dark'>s</span>
+    </div>
+  </div>
+</SettingCard>


### PR DESCRIPTION
Hi! So I noticed you could only seek +-2s with arrow keys which is tedious when you need to find that one specific part of the episode in the middle. So I defaulted the seek duration to 2s, but now its in Playback settings in case you need to increase (or decrease it)

![image](https://github.com/ThaUnknown/miru/assets/58628835/72a0b682-6d56-46ba-9303-b243329b89ea)

I also reload the keybinds everytime since I wanted to show how much it seeks when you open the settings as soon as you press the hotkey (`) or click the button since I cant figure out a more efficient way of hot reloading that part, but I dont think that matters too much with performance since it should consume negligible resources to reload hotkeys, when comparing to the entire app.

Thanks for this app, has to be my favourite apps in a while ❤️