### PR TITLE
Fix AniList completion for external players

### DIFF
--- a/common/views/Player/Player.svelte
+++ b/common/views/Player/Player.svelte
@@ -71,6 +71,7 @@
   let ended = false
   let volume = Number(localStorage.getItem('volume')) || 1
   let playbackRate = 1
+  let externalPlayerReady = false
   $: localStorage.setItem('volume', (volume || 0).toString())
   $: safeduration = (isFinite(duration) ? duration : currentTime) || 0
 
@@ -185,6 +186,7 @@
         const duration = current.media?.media?.duration
         client.removeEventListener('externalWatched', watchedListener)
         watchedListener = ({ detail }) => {
+          externalPlayerReady = true
           checkCompletionByTime(detail, duration)
         }
         client.on('externalWatched', watchedListener)
@@ -959,10 +961,11 @@
 
   function checkCompletionByTime (currentTime, safeduration) {
     const fromend = Math.max(180, safeduration / 10)
-    if (safeduration && currentTime && video?.readyState && safeduration - fromend < currentTime) {
+    if (safeduration && currentTime && (video?.readyState || externalPlayerReady) && safeduration - fromend < currentTime) {
       if (media?.media?.episodes || media?.media?.nextAiringEpisode?.episode) {
         if (media.media.episodes || media.media.nextAiringEpisode?.episode > media.episode) {
           completed = true
+          externalPlayerReady = false
           anilistClient.alEntry(media)
         }
       }


### PR DESCRIPTION
the AniList completion feature currently does not work with external players since the `video.readyState` is not being set
this PR should fix it